### PR TITLE
Update distributed.py

### DIFF
--- a/distributed.py
+++ b/distributed.py
@@ -1,120 +1,222 @@
 import torch
+from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
 import torch.distributed as dist
 from torch.nn.modules import Module
+from torch.autograd import Variable
+from collections import OrderedDict
 
-def _flatten_dense_tensors(tensors):
-    """Flatten dense tensors into a contiguous 1D buffer. Assume tensors are of
-    same dense type.
-    Since inputs are dense, the resulting tensor will be a concatenated 1D
-    buffer. Element-wise operation on this buffer will be equivalent to
-    operating individually.
-    Arguments:
-        tensors (Iterable[Tensor]): dense tensors to flatten.
-    Returns:
-        A contiguous 1D buffer containing input tensors.
-    """
-    if len(tensors) == 1:
-        return tensors[0].contiguous().view(-1)
-    flat = torch.cat([t.contiguous().view(-1) for t in tensors], dim=0)
-    return flat
 
-def _unflatten_dense_tensors(flat, tensors):
-    """View a flat buffer using the sizes of tensors. Assume that tensors are of
-    same dense type, and that flat is given by _flatten_dense_tensors.
-    Arguments:
-        flat (Tensor): flattened dense tensors to unflatten.
-        tensors (Iterable[Tensor]): dense tensors whose sizes will be used to
-          unflatten flat.
-    Returns:
-        Unflattened dense tensors with sizes same as tensors and values from
-        flat.
-    """
-    outputs = []
-    offset = 0
+def flat_dist_call(tensors, call, extra_args=None):
+    flat_dist_call.warn_on_half = True
+    buckets = OrderedDict()
     for tensor in tensors:
-        numel = tensor.numel()
-        outputs.append(flat.narrow(0, offset, numel).view_as(tensor))
-        offset += numel
-    return tuple(outputs)
+        tp = tensor.type()
+        if tp not in buckets:
+            buckets[tp] = []
+        buckets[tp].append(tensor)
+                    
+    if flat_dist_call.warn_on_half:
+        if torch.cuda.HalfTensor in buckets:
+            print("WARNING: gloo dist backend for half parameters may be extremely slow." +
+                  " It is recommended to use the NCCL backend in this case.")
+            flat_dist_call.warn_on_half = False
 
-
-'''
-This version of DistributedDataParallel is designed to be used in conjunction with the multiproc.py
-launcher included with this example. It assumes that your run is using multiprocess with 1
-GPU/process, that the model is on the correct device, and that torch.set_device has been
-used to set the device.
-
-Parameters are broadcasted to the other processes on initialization of DistributedDataParallel,
-and will be allreduced at the finish of the backward pass.
-'''
-class DistributedDataParallel(Module):
-
-    def __init__(self, module):
-        super(DistributedDataParallel, self).__init__()
-        #fallback for PyTorch 0.3
-        if not hasattr(dist, '_backend'):
-            self.warn_on_half = True
+    for tp in buckets:
+        bucket = buckets[tp]
+        coalesced = _flatten_dense_tensors(bucket)
+        if extra_args is not None:
+            call(coalesced, *extra_args)
         else:
-            self.warn_on_half = True if dist._backend == dist.dist_backend.GLOO else False
+            call(coalesced)
+        if call is dist.all_reduce:
+            coalesced /= dist.get_world_size()
+            
+        for buf, synced in zip(bucket, _unflatten_dense_tensors(coalesced, bucket)):
+            buf.copy_(synced)
+            
+class DistributedDataParallel(Module):
+    """
+    :class:`apex.parallel.DistributedDataParallel` is a module wrapper that enables
+    easy multiprocess distributed data parallel training, similar to ``torch.nn.parallel.DistributedDataParallel``.
 
+    :class:`DistributedDataParallel` is designed to work with
+    the launch utility script ``apex.parallel.multiproc.py``.  
+    When used with ``multiproc.py``, :class:`DistributedDataParallel` 
+    assigns 1 process to each of the available (visible) GPUs on the node.
+    Parameters are broadcast across participating processes on initialization, and gradients are
+    allreduced and averaged over processes during ``backward()``.
+
+    :class:`DistributedDataParallel` is optimized for use with NCCL.  It achieves high performance by 
+    overlapping communication with computation during ``backward()`` and bucketing smaller gradient
+    transfers to reduce the total number of transfers required.
+
+    :class:`DistributedDataParallel` assumes that your script accepts the command line 
+    arguments "rank" and "world-size."  It also assumes that your script calls
+    ``torch.cuda.set_device(args.rank)`` before creating the model.
+
+    https://github.com/NVIDIA/apex/tree/master/examples/distributed shows detailed usage.
+    https://github.com/NVIDIA/apex/tree/master/examples/imagenet shows another example
+    that combines :class:`DistributedDataParallel` with mixed precision training.
+
+    Args:
+        module: Network definition to be run in multi-gpu/distributed mode.
+        message_size (Default = 1e7): Minimum number of elements in a communication bucket.
+        shared_param (Default = False): If your model uses shared parameters this must be True.  It will disable bucketing of parameters to avoid race conditions.
+
+    """
+
+    def __init__(self, module, message_size=10000000, shared_param=False):
+        super(DistributedDataParallel, self).__init__()
+        self.warn_on_half = True if dist._backend == dist.dist_backend.GLOO else False
+        self.shared_param = shared_param
+        self.message_size = message_size
+        
+        #reference to last iterations parameters to see if anything has changed
+        self.param_refs = []
+        
+        self.reduction_stream = torch.cuda.Stream()
+        
         self.module = module
-
-        for p in self.module.state_dict().values():
-            if not torch.is_tensor(p):
-                continue
-            dist.broadcast(p, 0)
-
-        def allreduce_params():
-            if(self.needs_reduction):
-                self.needs_reduction = False
-                buckets = {}
-                for param in self.module.parameters():
-                    if param.requires_grad and param.grad is not None:
-                        tp = type(param.data)
-                        if tp not in buckets:
-                            buckets[tp] = []
-                        buckets[tp].append(param)
-                if self.warn_on_half:
-                    if torch.cuda.HalfTensor in buckets:
-                        print("WARNING: gloo dist backend for half parameters may be extremely slow." +
-                              " It is recommended to use the NCCL backend in this case. This currently requires" +
-                              "PyTorch built from top of tree master.")
-                        self.warn_on_half = False
-
-                for tp in buckets:
-                    bucket = buckets[tp]
-                    grads = [param.grad.data for param in bucket]
-                    coalesced = _flatten_dense_tensors(grads)
-                    dist.all_reduce(coalesced)
-                    coalesced /= dist.get_world_size()
-                    for buf, synced in zip(grads, _unflatten_dense_tensors(coalesced, grads)):
-                        buf.copy_(synced)
-
-        for param in list(self.module.parameters()):
-            def allreduce_hook(*unused):
-                param._execution_engine.queue_callback(allreduce_params)
-            if param.requires_grad:
-                param.register_hook(allreduce_hook)
-
-    def forward(self, *inputs, **kwargs):
-        self.needs_reduction = True
-        return self.module(*inputs, **kwargs)
-
-    '''
-    def _sync_buffers(self):
-        buffers = list(self.module._all_buffers())
-        if len(buffers) > 0:
-            # cross-node buffer sync
-            flat_buffers = _flatten_dense_tensors(buffers)
-            dist.broadcast(flat_buffers, 0)
-            for buf, synced in zip(buffers, _unflatten_dense_tensors(flat_buffers, buffers)):
-                buf.copy_(synced)
-     def train(self, mode=True):
-        # Clear NCCL communicator and CUDA event cache of the default group ID,
-        # These cache will be recreated at the later call. This is currently a
-        # work-around for a potential NCCL deadlock.
+        self.param_list = list(self.module.parameters())
+        
         if dist._backend == dist.dist_backend.NCCL:
-            dist._clear_group_cache()
-        super(DistributedDataParallel, self).train(mode)
-        self.module.train(mode)
-    '''
+            for param in self.param_list:
+                assert param.is_cuda, "NCCL backend only supports model parameters to be on GPU."
+                
+        self.record = []
+        self.create_hooks()
+
+        flat_dist_call([param.data for param in self.module.parameters()], dist.broadcast, (0,) )
+        
+    def create_hooks(self):
+        #all reduce gradient hook
+        def allreduce_params():
+            if not self.needs_reduction:
+                return
+            self.needs_reduction = False
+
+            #parameter ordering refresh
+            if self.needs_refresh and not self.shared_param:
+                t_record = torch.cuda.IntTensor(self.record)
+                dist.broadcast(t_record, 0)
+                self.record = [int(entry) for entry in t_record]
+                self.needs_refresh = False
+
+            grads = [param.grad.data for param in self.module.parameters() if param.grad is not None]
+            flat_dist_call(grads, dist.all_reduce)
+
+        def flush_buckets():
+            if not self.needs_reduction:
+                return
+            self.needs_reduction = False
+
+            grads = []
+            for i in range(self.ready_end, len(self.param_state)):
+                param = self.param_refs[self.record[i]]
+                if param.grad is not None:
+                    grads.append(param.grad.data)
+            grads = [param.grad.data for param in self.ready_params] + grads
+
+            if(len(grads)>0):
+                orig_stream = torch.cuda.current_stream()
+                with torch.cuda.stream(self.reduction_stream):
+                    self.reduction_stream.wait_stream(orig_stream)
+                    flat_dist_call(grads, dist.all_reduce)
+                    
+            torch.cuda.current_stream().wait_stream(self.reduction_stream)
+
+        for param_i, param in enumerate(list(self.module.parameters())):
+            def wrapper(param_i):
+                
+                def allreduce_hook(*unused):
+                    if self.needs_refresh:
+                        self.record.append(param_i)
+                        Variable._execution_engine.queue_callback(allreduce_params)
+                    else:
+                        Variable._execution_engine.queue_callback(flush_buckets)
+                        self.comm_ready_buckets(self.record.index(param_i))
+                    
+                    
+                if param.requires_grad:
+                    param.register_hook(allreduce_hook)
+            wrapper(param_i)
+
+
+    def comm_ready_buckets(self, param_ind):
+
+        if self.param_state[param_ind] != 0:
+            raise RuntimeError("Error: Your model uses shared parameters, DDP flag shared_params must be set to True in initialization.")
+            
+        
+        if self.param_state[self.ready_end] == 0:
+            self.param_state[param_ind] = 1
+            return
+
+
+        while self.ready_end < len(self.param_state) and self.param_state[self.ready_end] == 1:
+            self.ready_params.append(self.param_refs[self.record[self.ready_end]])
+            self.ready_numel += self.ready_params[-1].numel()
+            self.ready_end += 1
+
+
+        if self.ready_numel < self.message_size:
+            self.param_state[param_ind] = 1
+            return
+            
+        grads = [param.grad.data for param in self.ready_params]
+
+        bucket = []
+        bucket_inds = []
+        while grads:
+            bucket.append(grads.pop(0))
+            
+            cumm_size = 0
+            for ten in bucket:
+                cumm_size += ten.numel()
+
+            if cumm_size < self.message_size:
+                continue
+
+            evt = torch.cuda.Event()
+            evt.record(torch.cuda.current_stream())
+            evt.wait(stream=self.reduction_stream)
+        
+            with torch.cuda.stream(self.reduction_stream):
+                flat_dist_call(bucket, dist.all_reduce)
+
+            for i in range(self.ready_start, self.ready_start+len(bucket)):
+                self.param_state[i] = 2
+                self.ready_params.pop(0)
+
+        self.param_state[param_ind] = 1
+        
+    def forward(self, *inputs, **kwargs):
+
+        param_list = [param for param in list(self.module.parameters()) if param.requires_grad]
+
+
+        #Force needs_refresh to True if there are shared params
+        #this will force it to always, only call flush_buckets which is safe
+        #for shared parameters in the model.
+        #Parentheses are not necessary for correct order of operations, but make the intent clearer.
+        if (not self.param_refs) or self.shared_param:
+            self.needs_refresh = True
+        else:
+            self.needs_refresh = (
+                (len(param_list) != len(self.param_refs)) or any(
+                    [param1 is not param2 for param1, param2 in zip(param_list, self.param_refs)]))
+                
+        if  self.needs_refresh:
+            self.record = []
+
+            
+        self.param_state = [0 for i in range(len(param_list))]
+        self.param_refs = param_list
+        self.needs_reduction = True
+
+        self.ready_start = 0
+        self.ready_end   = 0
+        self.ready_params = []
+        self.ready_numel = 0
+        
+        return self.module(*inputs, **kwargs)


### PR DESCRIPTION
update from https://github.com/NVIDIA/apex/blob/master/apex/parallel/distributed.py
to resolve https://github.com/NVIDIA/tacotron2/issues/32

it works well 
```
root@a3404eef091b:/scratch/github/tacotron2# python -m multiproc train.py --output_directory=outdir --log_directory=logdir --hparams=distributed_run=True,fp16_run=True
['train.py', '--output_directory=outdir', '--log_directory=logdir', '--hparams=distributed_run=True,fp16_run=True', '--n_gpus=2', '--group_name=group_2018_07_04-043620', '--rank=0']
['train.py', '--output_directory=outdir', '--log_directory=logdir', '--hparams=distributed_run=True,fp16_run=True', '--n_gpus=2', '--group_name=group_2018_07_04-043620', '--rank=1']
FP16 Run: True
Dynamic Loss Scaling True
Distributed Run: True
cuDNN Enabled: True
cuDNN Benchmark: False
Initializing distributed
Done initializing distributed
/scratch/github/tacotron2/layers.py:35: UserWarning: nn.init.xavier_uniform is now deprecated in favor of nn.init.xavier_uniform_.
  self.conv.weight, gain=torch.nn.init.calculate_gain(w_init_gain))
/scratch/github/tacotron2/layers.py:35: UserWarning: nn.init.xavier_uniform is now deprecated in favor of nn.init.xavier_uniform_.
  self.conv.weight, gain=torch.nn.init.calculate_gain(w_init_gain))
/scratch/github/tacotron2/layers.py:15: UserWarning: nn.init.xavier_uniform is now deprecated in favor of nn.init.xavier_uniform_.
  gain=torch.nn.init.calculate_gain(w_init_gain))
/scratch/github/tacotron2/layers.py:15: UserWarning: nn.init.xavier_uniform is now deprecated in favor of nn.init.xavier_uniform_.
  gain=torch.nn.init.calculate_gain(w_init_gain))
Unexpected end of /proc/mounts line `overlay / overlay rw,relatime,lowerdir=/var/lib/docker/overlay2/l/N6KCJX53ZVFWPET6ANNB4G56TA:/var/lib/docker/overlay2/l/G45VXV2Q54CPZUAQL4LAGVMRNP:/var/lib/docker/overlay2/l/M66R6H36GKZBE6AJWO5XJT3WIN:/var/lib/docker/overlay2/l/Y3XCCSYU6OVYBAIFNMGDAJZK63:/var/lib/docker/overlay2/l/H4PMK5AXHM5Y3JQ62TNK6DU3XH:/var/lib/docker/overlay2/l/JZCXYXHRGEUZXQGQSF6YCGSSEO:/var/lib/docker/overlay2/l/TCNLFR6VQ6HLJS7RA73PHY6BPV:/var/lib/docker/overlay2/l/HEBHZMRUQRLODUD4FFXPR3QP55:/var/lib/docker/overlay2/l/C3HEY6CTKTDCB'
Unexpected end of /proc/mounts line `A53EKSMIG2CEV:/var/lib/docker/overlay2/l/VAYDIRS7RFDOWIACB6J55PIYCS:/var/lib/docker/overlay2/l/BE3VT6TJ3P4KLEMGEN62MQ77XU:/var/lib/docker/overlay2/l/OHFQX43BUCGRCPPB4AIKZZYGKM:/var/lib/docker/overlay2/l/6SKGKRFLXPUL3I4K73RNHTRJMI:/var/lib/docker/overlay2/l/WKUMSBR3ANKVVQNS4DNPKQ6Y2I:/var/lib/docker/overlay2/l/5VUVEPRQK7C5U3J7QHXRUDNS4R:/var/lib/docker/overlay2/l/TLGGZBFT3X2KJAO6CNIBPQAAVK:/var/lib/docker/overlay2/l/Z7F3AU7FEUUYMPZL5HMACWSCK2:/var/lib/docker/overlay2/l/OR2LHQCQNBIJCLNNSRS22AVQQR:/var/lib/do'
Unexpected end of /proc/mounts line `cker/overlay2/l/JXI5BOZPURCRDR7435WGUEE4YL:/var/lib/docker/overlay2/l/K72IUKSJE6CWH6NQIBZBHVLEEF:/var/lib/docker/overlay2/l/MZLD3BFR2FR7IIGUGEBAFUCZCB:/var/lib/docker/overlay2/l/DNRBNLILCVOG7O4Z33CY56N2ZB:/var/lib/docker/overlay2/l/7KMW2HAHUEQDD3YXCMSVWEMRF3:/var/lib/docker/overlay2/l/IWWISFRWP76WKCZZWVL7K3WWSS:/var/lib/docker/overlay2/l/H6JI6HY6GHWBCGLHDO5DFX7AER:/var/lib/docker/overlay2/l/OSAI5JM7ADXEEPEPQ2RU5744Z6:/var/lib/docker/overlay2/l/KNRKD7BXTAMSVT47YBIPHJY7V5:/var/lib/docker/overlay2/l/K2MS2FUDS'
Unexpected end of /proc/mounts line `Q2XSWMONGEF2OIXYY:/var/lib/docker/overlay2/l/FWATL67YTWL2TYXRQ4X5XGO7YL:/var/lib/docker/overlay2/l/LPOBTG2MZDRFUIED5G7VCHHGAD:/var/lib/docker/overlay2/l/LLJZJ3EZZQGPN6WKKO5BGX27BM:/var/lib/docker/overlay2/l/Z5SXBCKEGSFAPNTWQKBAY654JP:/var/lib/docker/overlay2/l/WK6EL2UGKFSULWXZOC77HYBYZC:/var/lib/docker/overlay2/l/5DCUE5SKFG7QN5M5T7KAO63Z6Y:/var/lib/docker/overlay2/l/UFJAPPR5TPCJI5OU64EJOWQLVO:/var/lib/docker/overlay2/l/UFV5HHWWX2RV2PATQYZXSMDBHE:/var/lib/docker/overlay2/l/OJZXT4SPS5M7GDV3Z7RTCPEKNS:/var/li'
Unexpected end of /proc/mounts line `overlay / overlay rw,relatime,lowerdir=/var/lib/docker/overlay2/l/N6KCJX53ZVFWPET6ANNB4G56TA:/var/lib/docker/overlay2/l/G45VXV2Q54CPZUAQL4LAGVMRNP:/var/lib/docker/overlay2/l/M66R6H36GKZBE6AJWO5XJT3WIN:/var/lib/docker/overlay2/l/Y3XCCSYU6OVYBAIFNMGDAJZK63:/var/lib/docker/overlay2/l/H4PMK5AXHM5Y3JQ62TNK6DU3XH:/var/lib/docker/overlay2/l/JZCXYXHRGEUZXQGQSF6YCGSSEO:/var/lib/docker/overlay2/l/TCNLFR6VQ6HLJS7RA73PHY6BPV:/var/lib/docker/overlay2/l/HEBHZMRUQRLODUD4FFXPR3QP55:/var/lib/docker/overlay2/l/C3HEY6CTKTDCB'
Unexpected end of /proc/mounts line `A53EKSMIG2CEV:/var/lib/docker/overlay2/l/VAYDIRS7RFDOWIACB6J55PIYCS:/var/lib/docker/overlay2/l/BE3VT6TJ3P4KLEMGEN62MQ77XU:/var/lib/docker/overlay2/l/OHFQX43BUCGRCPPB4AIKZZYGKM:/var/lib/docker/overlay2/l/6SKGKRFLXPUL3I4K73RNHTRJMI:/var/lib/docker/overlay2/l/WKUMSBR3ANKVVQNS4DNPKQ6Y2I:/var/lib/docker/overlay2/l/5VUVEPRQK7C5U3J7QHXRUDNS4R:/var/lib/docker/overlay2/l/TLGGZBFT3X2KJAO6CNIBPQAAVK:/var/lib/docker/overlay2/l/Z7F3AU7FEUUYMPZL5HMACWSCK2:/var/lib/docker/overlay2/l/OR2LHQCQNBIJCLNNSRS22AVQQR:/var/lib/do'
Unexpected end of /proc/mounts line `cker/overlay2/l/JXI5BOZPURCRDR7435WGUEE4YL:/var/lib/docker/overlay2/l/K72IUKSJE6CWH6NQIBZBHVLEEF:/var/lib/docker/overlay2/l/MZLD3BFR2FR7IIGUGEBAFUCZCB:/var/lib/docker/overlay2/l/DNRBNLILCVOG7O4Z33CY56N2ZB:/var/lib/docker/overlay2/l/7KMW2HAHUEQDD3YXCMSVWEMRF3:/var/lib/docker/overlay2/l/IWWISFRWP76WKCZZWVL7K3WWSS:/var/lib/docker/overlay2/l/H6JI6HY6GHWBCGLHDO5DFX7AER:/var/lib/docker/overlay2/l/OSAI5JM7ADXEEPEPQ2RU5744Z6:/var/lib/docker/overlay2/l/KNRKD7BXTAMSVT47YBIPHJY7V5:/var/lib/docker/overlay2/l/K2MS2FUDS'
Unexpected end of /proc/mounts line `Q2XSWMONGEF2OIXYY:/var/lib/docker/overlay2/l/FWATL67YTWL2TYXRQ4X5XGO7YL:/var/lib/docker/overlay2/l/LPOBTG2MZDRFUIED5G7VCHHGAD:/var/lib/docker/overlay2/l/LLJZJ3EZZQGPN6WKKO5BGX27BM:/var/lib/docker/overlay2/l/Z5SXBCKEGSFAPNTWQKBAY654JP:/var/lib/docker/overlay2/l/WK6EL2UGKFSULWXZOC77HYBYZC:/var/lib/docker/overlay2/l/5DCUE5SKFG7QN5M5T7KAO63Z6Y:/var/lib/docker/overlay2/l/UFJAPPR5TPCJI5OU64EJOWQLVO:/var/lib/docker/overlay2/l/UFV5HHWWX2RV2PATQYZXSMDBHE:/var/lib/docker/overlay2/l/OJZXT4SPS5M7GDV3Z7RTCPEKNS:/var/li'
FP16_Optimizer processing param group 0:
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([149, 512])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([512, 512, 5])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([512])
FP16_Optimizer received torch.cuda.FloatTensor with torch.Size([512])
FP16_Optimizer received torch.cuda.FloatTensor with torch.Size([512])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([512, 512, 5])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([512])
FP16_Optimizer received torch.cuda.FloatTensor with torch.Size([512])
FP16_Optimizer received torch.cuda.FloatTensor with torch.Size([512])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([512, 512, 5])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([512])
FP16_Optimizer received torch.cuda.FloatTensor with torch.Size([512])
FP16_Optimizer received torch.cuda.FloatTensor with torch.Size([512])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([1024, 512])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([1024, 256])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([1024])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([1024])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([1024, 512])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([1024, 256])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([1024])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([1024])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([256, 80])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([256, 256])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([4096, 768])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([4096, 1024])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([4096])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([4096])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([128, 1024])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([128, 512])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([1, 128])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([32, 2, 31])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([128, 32])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([4096, 1536])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([4096, 1024])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([4096])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([4096])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([80, 1536])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([80])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([1, 1536])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([1])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([512, 80, 5])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([512])
FP16_Optimizer received torch.cuda.FloatTensor with torch.Size([512])
FP16_Optimizer received torch.cuda.FloatTensor with torch.Size([512])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([512, 512, 5])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([512])
FP16_Optimizer received torch.cuda.FloatTensor with torch.Size([512])
FP16_Optimizer received torch.cuda.FloatTensor with torch.Size([512])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([512, 512, 5])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([512])
FP16_Optimizer received torch.cuda.FloatTensor with torch.Size([512])
FP16_Optimizer received torch.cuda.FloatTensor with torch.Size([512])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([512, 512, 5])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([512])
FP16_Optimizer received torch.cuda.FloatTensor with torch.Size([512])
FP16_Optimizer received torch.cuda.FloatTensor with torch.Size([512])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([80, 512, 5])
FP16_Optimizer received torch.cuda.HalfTensor with torch.Size([80])
FP16_Optimizer received torch.cuda.FloatTensor with torch.Size([80])
FP16_Optimizer received torch.cuda.FloatTensor with torch.Size([80])
Epoch:     0
train.py:200: UserWarning: invalid index of a 0-dim tensor. This will be an error in PyTorch 0.5. Use tensor.item() to convert a 0-dim tensor to a Python number
  if hparams.distributed_run else loss.data[0]
train.py:200: UserWarning: invalid index of a 0-dim tensor. This will be an error in PyTorch 0.5. Use tensor.item() to convert a 0-dim tensor to a Python number
  if hparams.distributed_run else loss.data[0]
OVERFLOW! Skipping step. Attempted loss scale: 4294967296
OVERFLOW! Skipping step. Attempted loss scale: 2147483648.0
OVERFLOW! Skipping step. Attempted loss scale: 1073741824.0
OVERFLOW! Skipping step. Attempted loss scale: 536870912.0
OVERFLOW! Skipping step. Attempted loss scale: 268435456.0
OVERFLOW! Skipping step. Attempted loss scale: 134217728.0
OVERFLOW! Skipping step. Attempted loss scale: 67108864.0
OVERFLOW! Skipping step. Attempted loss scale: 33554432.0
OVERFLOW! Skipping step. Attempted loss scale: 16777216.0
OVERFLOW! Skipping step. Attempted loss scale: 8388608.0
OVERFLOW! Skipping step. Attempted loss scale: 4194304.0
OVERFLOW! Skipping step. Attempted loss scale: 2097152.0
OVERFLOW! Skipping step. Attempted loss scale: 1048576.0
OVERFLOW! Skipping step. Attempted loss scale: 524288.0
OVERFLOW! Skipping step. Attempted loss scale: 262144.0
OVERFLOW! Skipping step. Attempted loss scale: 131072.0
/scratch/github/tacotron2/fp16_optimizer.py:173: UserWarning: torch.nn.utils.clip_grad_norm is now deprecated in favor of torch.nn.utils.clip_grad_norm_.
  return torch.nn.utils.clip_grad_norm(fp32_params, clip)
Train iter       16 loss 49.316841 Grad Norm 10.800460 3.22s/it
/scratch/github/tacotron2/fp16_optimizer.py:173: UserWarning: torch.nn.utils.clip_grad_norm is now deprecated in favor of torch.nn.utils.clip_grad_norm_.
  return torch.nn.utils.clip_grad_norm(fp32_params, clip)
OVERFLOW! Skipping step. Attempted loss scale: 65536.0
Train iter       18 loss 40.572620 Grad Norm 24.962288 3.18s/it
Train iter       19 loss 23.865871 Grad Norm 18.794416 3.18s/it
Train iter       20 loss 13.441618 Grad Norm 15.939060 3.23s/it
Train iter       21 loss 7.951932 Grad Norm 8.706021 3.25s/it
Train iter       22 loss 6.590442 Grad Norm 6.689472 3.16s/it
Train iter       23 loss 6.191196 Grad Norm 6.757519 3.13s/it
Train iter       24 loss 5.509645 Grad Norm 6.079108 3.19s/it
Train iter       25 loss 5.355157 Grad Norm 7.703736 3.02s/it
Train iter       26 loss 4.984959 Grad Norm 5.296627 3.18s/it
Train iter       27 loss 4.464544 Grad Norm 4.186379 3.20s/it
Train iter       28 loss 4.435464 Grad Norm 4.557209 3.27s/it
Train iter       29 loss 4.334722 Grad Norm 8.194729 3.17s/it
Train iter       30 loss 4.163740 Grad Norm 3.329817 3.18s/it
Train iter       31 loss 3.863928 Grad Norm 3.288409 3.16s/it
Train iter       32 loss 4.195742 Grad Norm 10.788541 3.10s/it
Train iter       33 loss 3.772189 Grad Norm 1.974833 3.23s/it
Train iter       34 loss 4.499164 Grad Norm 11.733442 3.14s/it
Train iter       35 loss 4.278608 Grad Norm 7.804421 3.24s/it
Train iter       36 loss 4.177848 Grad Norm 5.837828 3.10s/it
Train iter       37 loss 3.894197 Grad Norm 5.884570 3.17s/it
Train iter       38 loss 3.733924 Grad Norm 2.546655 3.22s/it
Train iter       39 loss 3.920209 Grad Norm 9.012811 3.21s/it
Train iter       40 loss 3.944991 Grad Norm 8.163858 3.22s/it
Train iter       41 loss 3.694589 Grad Norm 3.208256 3.19s/it
Train iter       42 loss 3.463051 Grad Norm 2.812034 3.13s/it
Train iter       43 loss 3.742120 Grad Norm 3.808256 3.27s/it
Train iter       44 loss 3.648834 Grad Norm 1.847008 3.19s/it
Train iter       45 loss 3.873199 Grad Norm 6.838338 3.29s/it
Train iter       46 loss 3.941565 Grad Norm 6.975150 3.23s/it
Train iter       47 loss 3.706520 Grad Norm 2.846996 3.24s/it
Train iter       48 loss 3.709265 Grad Norm 4.831077 3.03s/it
Train iter       49 loss 3.582793 Grad Norm 1.885498 3.22s/it
Train iter       50 loss 3.525973 Grad Norm 0.910370 3.39s/it
Train iter       51 loss 3.470527 Grad Norm 3.723825 3.25s/it
```